### PR TITLE
Fix code block visibility in light mode

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -36,7 +36,10 @@ export default defineConfig({
 
 	markdown: {
 		shikiConfig: {
-			theme: 'dracula',
+			themes: {
+				light: 'github-light',
+				dark: 'dracula',
+			},
 			wrap: true,
 		},
 	},

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -161,10 +161,17 @@
 
 @layer base {
 	/* Shiki dual theme support - switch between light and dark themes */
+	.astro-code {
+		border: 1px solid var(--color-gray-200);
+		border-radius: 0.5rem;
+	}
 	.astro-code,
 	.astro-code span {
 		color: var(--shiki-light) !important;
 		background-color: var(--shiki-light-bg) !important;
+	}
+	.dark .astro-code {
+		border-color: transparent;
 	}
 	.dark .astro-code,
 	.dark .astro-code span {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -160,6 +160,17 @@
 }
 
 @layer base {
+	/* Shiki dual theme support - switch between light and dark themes */
+	.astro-code,
+	.astro-code span {
+		color: var(--shiki-light) !important;
+		background-color: var(--shiki-light-bg) !important;
+	}
+	.dark .astro-code,
+	.dark .astro-code span {
+		color: var(--shiki-dark) !important;
+		background-color: var(--shiki-dark-bg) !important;
+	}
 	/*
 The default border color has changed to `currentColor` in Tailwind CSS v4,
 so we've added these compatibility styles to make sure everything still

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -171,7 +171,7 @@
 		background-color: var(--shiki-light-bg) !important;
 	}
 	.dark .astro-code {
-		border-color: transparent;
+		border-color: var(--color-gray-700);
 	}
 	.dark .astro-code,
 	.dark .astro-code span {


### PR DESCRIPTION
Use Shiki dual themes (github-light for light mode, dracula for dark) with CSS variable switching to ensure code blocks are readable in both light and dark modes.